### PR TITLE
Prepare for upcoming change to HttpRequest and HttpClientResponse

### DIFF
--- a/lib/src/utils/request.dart
+++ b/lib/src/utils/request.dart
@@ -29,7 +29,7 @@ class Requests {
  Future<Item> get(url) async {
     var request = await HttpClient().getUrl(Uri.parse(url));
     var response = await request.close();
-    final future = await response.transform(Utf8Decoder());
+    final future = await Utf8Decoder().bind(response);
     var ror="";
     await for (var string in future) {
       if (string != "" && string != null && string != "null") {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: popcorn_api
 author: acnologla2121@gmail.com
-version: 1.1.2
+version: 1.1.3
 homepage: https://github.com/Acnologla/PopcornAPi/
 environment:
  sdk: ">=2.0.0-dev.63.0 <3.0.0"


### PR DESCRIPTION
An upcoming change to the Dart SDK will change `HttpRequest` and
`HttpClientResponse` from implementing `Stream<List<int>>` to
implementing `Stream<Uint8List>`.

This forwards-compatible change prepares for that SDK breaking
change by casting the Stream to `List<int>` before transforming
it.

https://github.com/dart-lang/sdk/issues/36900